### PR TITLE
Fix critic scheduler initialization in PPO agents

### DIFF
--- a/src/cooperative_navigation_stage_parallel/agent.py
+++ b/src/cooperative_navigation_stage_parallel/agent.py
@@ -59,7 +59,7 @@ class PPOAgent:
         self.replay_memory_buffer = ReplayMemoryBuffer(self.buffer_size, self.batch_size, self.device)
 
         self.actor_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
-        self.critic_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
+        self.critic_scheduler = LambdaLR(self.critic_optimizer, lr_lambda=self.scheduler)
 
         self.logger = Logger(self.dir_name, self.n_actions)
     def get_action(self, id, state, local_actor, logger_dict, collect_action_flag):

--- a/src/dynamic_obstacle_stage_parallel/agent.py
+++ b/src/dynamic_obstacle_stage_parallel/agent.py
@@ -53,7 +53,7 @@ class PPOAgent:
         self.replay_memory_buffer = ReplayMemoryBuffer(self.buffer_size, self.batch_size, self.device)
 
         self.actor_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
-        self.critic_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
+        self.critic_scheduler = LambdaLR(self.critic_optimizer, lr_lambda=self.scheduler)
 
         self.logger = Logger(self.dir_name, self.n_actions)
     def get_action(self, id, state, local_actor):

--- a/src/non_obstacle_stage_parallel/agent.py
+++ b/src/non_obstacle_stage_parallel/agent.py
@@ -50,7 +50,7 @@ class PPOAgent:
         self.replay_memory_buffer = ReplayMemoryBuffer(self.buffer_size, self.batch_size, self.device)
 
         self.actor_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
-        self.critic_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
+        self.critic_scheduler = LambdaLR(self.critic_optimizer, lr_lambda=self.scheduler)
         self.logger = Logger(self.dir_name, self.n_actions)
         self.load_weights("./ppo_Parallel-Non-Obstacle/2023-12-23_01-48-03/300_weights.pth")
 

--- a/src/static_obstacle_stage_parallel/agent.py
+++ b/src/static_obstacle_stage_parallel/agent.py
@@ -53,7 +53,7 @@ class PPOAgent:
         self.replay_memory_buffer = ReplayMemoryBuffer(self.buffer_size, self.batch_size, self.device)
 
         self.actor_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
-        self.critic_scheduler = LambdaLR(self.actor_optimizer, lr_lambda=self.scheduler)
+        self.critic_scheduler = LambdaLR(self.critic_optimizer, lr_lambda=self.scheduler)
 
         self.logger = Logger(self.dir_name, self.n_actions)
     def get_action(self, id, state, local_actor):


### PR DESCRIPTION
## Summary
- correct optimizer argument for critic LR schedulers across agents

## Testing
- `python3 -m py_compile src/dynamic_obstacle_stage_parallel/agent.py src/static_obstacle_stage_parallel/agent.py src/non_obstacle_stage_parallel/agent.py src/cooperative_navigation_stage_parallel/agent.py`

------
https://chatgpt.com/codex/tasks/task_e_683c395d86dc832ea55b9814a91607af